### PR TITLE
For now, no need to publish to crates.io

### DIFF
--- a/.release-plz.toml
+++ b/.release-plz.toml
@@ -12,3 +12,4 @@ git_release_name = "v{{ version }}"
 git_tag_name = "v{{ version }}"
 git_tag_enable = true
 git_release_enable = true
+publish = false


### PR DESCRIPTION
This may not work, as `release-plz` seems to depend on crates.io publishing to determine nextver.